### PR TITLE
Add support for plugin elements in backported FlashComponent

### DIFF
--- a/lib/Cake/Controller/Component/FlashComponent.php
+++ b/lib/Cake/Controller/Component/FlashComponent.php
@@ -112,6 +112,10 @@ class FlashComponent extends Component {
 		}
 
 		if (!empty($args[1])) {
+                        if (!empty($args[1]['plugin'])) {
+                                $options = ['element' => $args[1]['plugin'] . '.' . $options['element']];
+                                unset($args[1]['plugin']);
+                        }
 			$options += (array)$args[1];
 		}
 


### PR DESCRIPTION
When FlashComponent was backported from 3.0, the code supporting plugin elements was omitted. This commit includes it.
